### PR TITLE
[#17] - Disallow negative maxRetries and waitTime arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - "1.11.x"
+  - 1.11.x
+  - tip
 
 os:
   - linux
@@ -12,6 +13,12 @@ dist: trusty
 sudo: false
 install: true
 
+before_install:
+  - go get -t -v ./...
+
 script:
   - env GO111MODULE=on go build
-  - env GO111MODULE=on go test
+  - env GO111MODULE=on go test -coverprofile=coverage.txt -covermode=atomic
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/MethodCallRetrier.go
+++ b/MethodCallRetrier.go
@@ -33,8 +33,12 @@ func New(waitTime int64, maxRetries int64, exponent *int64) *MethodCallRetrier {
 		exponent = &defaultInt
 	}
 
-	if maxRetries <= 0 {
-		maxRetries = 0
+	if maxRetries < 1 {
+		maxRetries = 1
+	}
+
+	if waitTime <= 0 {
+		waitTime = 0
 	}
 
 	return &MethodCallRetrier{waitTime: waitTime, maxRetries: maxRetries, exponent: *exponent}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ MethodCallRetrier
 
 [![Build Status](https://travis-ci.org/J7mbo/MethodCallRetrier.svg?branch=master)](https://travis-ci.org/J7mbo/MethodCallRetrier)
 [![GoDoc](https://godoc.org/github.com/J7mbo/MethodCallRetrier?status.svg)](https://godoc.org/github.com/J7mbo/MethodCallRetrier)
+[![codecov](https://img.shields.io/codecov/c/github.com/j7mbo/MethodCallRetrier/master.svg)](https://codecov.io/gh/J7mbo/MethodCallRetrier)
 
 Features
 -


### PR DESCRIPTION
Also defaults retries to 1 if given less - expected functionality in using a retrier anyway so not even a feature release required